### PR TITLE
Add wacz-auth spec version to output

### DIFF
--- a/wacz_signing/signer.py
+++ b/wacz_signing/signer.py
@@ -132,6 +132,7 @@ def sign(string, dt):
 
     return {
         'software': f"wacz-signing {__version__}",
+        'version': '0.1.0',
         'hash': string,
         'created': dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
         'signature': signature,


### PR DESCRIPTION
This PR adds a `version` property to the signature object, specifying which version of the wacz-auth spec is being used.

Language around this property is loose in the spec: https://specs.webrecorder.net/wacz-auth/0.1.0/#domain-ownership-identity-signed-timestamp 